### PR TITLE
Add architecture lint tooling

### DIFF
--- a/architecture-rules.yaml
+++ b/architecture-rules.yaml
@@ -1,0 +1,3 @@
+# Architecture lint configuration
+# requireCriticalRule: if true, architecture docs must contain <critical_rule>
+requireCriticalRule: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,7 @@
+# Project Architecture
+
+<critical_rule>
+All components must follow the modular structure defined in this document.
+</critical_rule>
+
+This file describes the high level system design.

--- a/docs/architecture/coding-standards.md
+++ b/docs/architecture/coding-standards.md
@@ -1,0 +1,3 @@
+# Coding Standards
+
+Use consistent formatting and linting.

--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -1,0 +1,3 @@
+# Source Tree
+
+This directory explains the project structure.

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -1,0 +1,4 @@
+# Tech Stack
+
+- Node.js
+- YAML

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:teams": "node tools/cli.js build --teams-only",
     "list:agents": "node tools/cli.js list:agents",
     "validate": "node tools/cli.js validate",
+    "lint:architecture": "node tools/cli.js lint:architecture",
     "install:bmad": "node tools/installer/bin/bmad.js install",
     "format": "prettier --write \"**/*.md\"",
     "version:patch": "node tools/version-bump.js patch",

--- a/tools/architecture-lint.js
+++ b/tools/architecture-lint.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { lintArchitecture } = require('./lib/architecture-linter');
+
+const args = process.argv.slice(2);
+const configFile = args[0] || 'architecture-rules.yaml';
+
+try {
+  lintArchitecture({ configFile });
+  console.log('Architecture lint passed');
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -114,22 +114,37 @@ program
       // Validate by attempting to build all agents and teams
       const agents = await builder.resolver.listAgents();
       const teams = await builder.resolver.listTeams();
-      
+
       console.log('Validating agents...');
       for (const agent of agents) {
         await builder.resolver.resolveAgentDependencies(agent);
         console.log(`  ✓ ${agent}`);
       }
-      
+
       console.log('\nValidating teams...');
       for (const team of teams) {
         await builder.resolver.resolveTeamDependencies(team);
         console.log(`  ✓ ${team}`);
       }
-      
+
       console.log('\nAll configurations are valid!');
     } catch (error) {
       console.error('Validation failed:', error.message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('lint:architecture')
+  .description('Enforce architecture and safety rules')
+  .option('-c, --config <path>', 'Path to architecture rules file', 'architecture-rules.yaml')
+  .action((options) => {
+    const { lintArchitecture } = require('./lib/architecture-linter');
+    try {
+      lintArchitecture({ rootDir: process.cwd(), configFile: options.config });
+      console.log('Architecture lint passed!');
+    } catch (error) {
+      console.error('Architecture lint failed:', error.message);
       process.exit(1);
     }
   });

--- a/tools/lib/architecture-linter.js
+++ b/tools/lib/architecture-linter.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Lint architecture and safety rules
+ * @param {object} options
+ * @param {string} options.rootDir - repository root
+ * @param {string} options.configFile - architecture rule config
+ */
+function lintArchitecture(options = {}) {
+  const rootDir = options.rootDir || process.cwd();
+  const configFile = options.configFile || 'architecture-rules.yaml';
+
+  const coreConfigPath = path.join(rootDir, 'bmad-core', 'core-config.yaml');
+  if (!fs.existsSync(coreConfigPath)) {
+    throw new Error('Missing bmad-core/core-config.yaml');
+  }
+
+  const coreContent = fs.readFileSync(coreConfigPath, 'utf8');
+  const archSettings = {
+    architectureFile: (coreContent.match(/architectureFile:\s*(.*)/) || [])[1],
+    architectureSharded: /architectureSharded:\s*true/.test(coreContent),
+    architectureShardedLocation: (coreContent.match(/architectureShardedLocation:\s*(.*)/) || [])[1]
+  };
+  const archFile = path.join(rootDir, archSettings.architectureFile || 'docs/architecture.md');
+
+  let failed = false;
+
+  if (!fs.existsSync(archFile)) {
+    console.error(`\u274c Architecture file not found: ${archSettings.architectureFile}`);
+    failed = true;
+  }
+
+  if (archSettings.architectureSharded) {
+    const shardDir = path.join(rootDir, archSettings.architectureShardedLocation || '');
+    if (!fs.existsSync(shardDir)) {
+      console.error(`\u274c Architecture shard directory missing: ${archSettings.architectureShardedLocation}`);
+      failed = true;
+    }
+  }
+
+  const rulesPath = path.join(rootDir, configFile);
+  let rules = {};
+  if (fs.existsSync(rulesPath)) {
+    const ruleContent = fs.readFileSync(rulesPath, 'utf8');
+    const match = ruleContent.match(/requireCriticalRule:\s*(.*)/);
+    if (match) {
+      rules.requireCriticalRule = match[1].trim() === 'true';
+    }
+  }
+
+  if (rules.requireCriticalRule && fs.existsSync(archFile)) {
+    const content = fs.readFileSync(archFile, 'utf8');
+    if (!content.includes('<critical_rule>')) {
+      console.error(`\u274c ${archSettings.architectureFile} must contain '<critical_rule>' markers`);
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    throw new Error('Architecture lint failed');
+  }
+}
+
+module.exports = { lintArchitecture };


### PR DESCRIPTION
## Summary
- implement architecture lint tool and CLI command
- add example architecture rules config
- document architecture folder and base architecture file

## Testing
- `node tools/architecture-lint.js`

------
https://chatgpt.com/codex/tasks/task_e_687814751ce4832fb0edda38193035fa