### PR TITLE
Fix dependency path extension duplication

### DIFF
--- a/tools/installer/lib/config-loader.js
+++ b/tools/installer/lib/config-loader.js
@@ -144,7 +144,8 @@ class ConfigLoader {
     
     // Add all resolved resources
     for (const resource of agentDeps.resources) {
-      const filePath = `.bmad-core/${resource.type}/${resource.id}.md`;
+      // resource.id already includes the appropriate extension
+      const filePath = `.bmad-core/${resource.type}/${resource.id}`;
       if (!depPaths.includes(filePath)) {
         depPaths.push(filePath);
       }
@@ -237,7 +238,8 @@ class ConfigLoader {
       
       // Add all resolved resources
       for (const resource of teamDeps.resources) {
-        const filePath = `.bmad-core/${resource.type}/${resource.id}.${resource.type === 'workflows' ? 'yaml' : 'md'}`;
+        // resource.id already includes the appropriate extension
+        const filePath = `.bmad-core/${resource.type}/${resource.id}`;
         if (!depPaths.includes(filePath)) {
           depPaths.push(filePath);
         }


### PR DESCRIPTION
## Summary
- fix ConfigLoader so dependencies keep their original extensions

## Testing
- `npm run build -- --agents-only` *(fails: cannot find module 'commander')*

------
https://chatgpt.com/codex/tasks/task_e_6878104c05c8832fb030311ad1f0634d